### PR TITLE
Bug/subir imagenes grandes

### DIFF
--- a/sosafitos/settings.py
+++ b/sosafitos/settings.py
@@ -130,3 +130,8 @@ CRISPY_TEMPLATE_PACK = 'bootstrap4'
 
 # URLs
 LOGIN_URL = '/login'
+
+LOCATION_FIELD = {
+    'map.provider': 'openstreetmap',
+    'map.zoom':3
+}

--- a/sosafitosapp/models.py
+++ b/sosafitosapp/models.py
@@ -32,4 +32,4 @@ class Reporte(models.Model):
         if img.height>1080 or img.width> 1920:
             output_size = (1920,1080)
             img.thumbnail(output_size)
-            img.save(self.image.path)
+            img.save(self.foto.path)


### PR DESCRIPTION
Arreglados bugs para subir imagenes grandes (sobre 1920x1080) y cambiado proveedor a openstreetmaps

#Como probar
- Intentar crear reporte y colocar una imagen grande (no deberia tirar error), tambien se puede verificar que los mapas no presentan un mensaje de error y tienen un zooma mas apropiado